### PR TITLE
Add more filtering options

### DIFF
--- a/src/combo/criteria.ts
+++ b/src/combo/criteria.ts
@@ -16,10 +16,6 @@ import { Character } from "../melee/characters";
  */
 export class MatchesPortNumber implements Criteria {
   public check(combo: ComboType, settings: GameStartType, options: ComboFilterSettings): boolean {
-    if (options.portFilter.length === 0) {
-      return true;
-    }
-
     const player = _.find(settings.players, (player) => player.playerIndex === combo.playerIndex);
     return options.portFilter.includes(player.playerIndex);
   }

--- a/src/combo/criteria.ts
+++ b/src/combo/criteria.ts
@@ -97,6 +97,13 @@ export class ExcludesWobbles implements Criteria {
   }
 }
 
+export class SatisfiesMinComboLength implements Criteria {
+  public check(combo: ComboType, settings: GameStartType, options: ComboFilterSettings): boolean {
+    const numMoves = combo.moves.length;
+    return numMoves >= options.minComboLength;
+  }
+}
+
 export class SatisfiesMinComboPercent implements Criteria {
   public check(combo: ComboType, settings: GameStartType, options: ComboFilterSettings): boolean {
     const player = _.find(settings.players, (player) => player.playerIndex === combo.playerIndex);

--- a/src/combo/criteria.ts
+++ b/src/combo/criteria.ts
@@ -5,6 +5,26 @@ import { ComboType, GameStartType } from "slp-parser-js";
 import { MoveID } from "../melee/moves";
 import { Character } from "../melee/characters";
 
+/**
+ * MatchesPortNumber ensures the player performing the combo is a specific port.
+ * The port to be matched against is zero indexed. This means that player 1 is
+ * has the index 0, and player 2 has the index 1 etc.
+ *
+ * @export
+ * @class MatchesPortNumber
+ * @implements {Criteria}
+ */
+export class MatchesPortNumber implements Criteria {
+  public check(combo: ComboType, settings: GameStartType, options: ComboFilterSettings): boolean {
+    if (options.portFilter.length === 0) {
+      return true;
+    }
+
+    const player = _.find(settings.players, (player) => player.playerIndex === combo.playerIndex);
+    return options.portFilter.includes(player.playerIndex);
+  }
+}
+
 export class MatchesPlayerName implements Criteria {
   public check(combo: ComboType, settings: GameStartType, options: ComboFilterSettings): boolean {
     if (options.nameTags.length === 0) {

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -1,10 +1,11 @@
 import { Character } from "../melee/characters";
 import { ComboType, GameStartType } from "slp-parser-js";
-import { MatchesPlayerName, ExcludesChainGrabs, ExcludesWobbles, SatisfiesMinComboPercent, ExcludesLargeSingleHit, ExcludesCPUs, IsOneVsOne, ComboDidKill, MatchesCharacter } from "./criteria";
+import { MatchesPlayerName, ExcludesChainGrabs, ExcludesWobbles, SatisfiesMinComboPercent, ExcludesLargeSingleHit, ExcludesCPUs, IsOneVsOne, ComboDidKill, MatchesCharacter, MatchesPortNumber } from "./criteria";
 
 export interface ComboFilterSettings {
   chainGrabbers: Character[];
   characterFilter: Character[];
+  portFilter: number[];
   nameTags: string[];
   minComboPercent: number;
   comboMustKill: boolean;
@@ -24,6 +25,7 @@ export interface Criteria {
 const defaultSettings: ComboFilterSettings = {
   chainGrabbers: [Character.MARTH, Character.PEACH, Character.PIKACHU, Character.DR_MARIO],
   characterFilter: [],
+  portFilter: [],
   nameTags: [],
   minComboPercent: 60,
   comboMustKill: true,
@@ -48,6 +50,7 @@ export class ComboFilter {
     this.originalSettings = Object.assign({}, this.settings);
     this.criteria = new Array<Criteria>();
     this.criteria.push(
+      new MatchesPortNumber(),
       new MatchesPlayerName(),
       new MatchesCharacter(),
       new ExcludesChainGrabs(),

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -28,7 +28,7 @@ const defaultSettings: ComboFilterSettings = {
   characterFilter: [],
   portFilter: [0, 1, 2, 3], // Enable combos for all ports
   nameTags: [],
-  minComboLength: 3,
+  minComboLength: 1,
   minComboPercent: 60,
   comboMustKill: true,
   excludeCPUs: true,

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -26,7 +26,7 @@ export interface Criteria {
 const defaultSettings: ComboFilterSettings = {
   chainGrabbers: [Character.MARTH, Character.PEACH, Character.PIKACHU, Character.DR_MARIO],
   characterFilter: [],
-  portFilter: [],
+  portFilter: [0, 1, 2, 3], // Enable combos for all ports
   nameTags: [],
   minComboLength: 0,
   minComboPercent: 60,

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -39,9 +39,9 @@ const defaultSettings: ComboFilterSettings = {
 }
 
 export class ComboFilter {
+  public criteria: Criteria[];
   private settings: ComboFilterSettings;
   private originalSettings: ComboFilterSettings;
-  private criteria: Criteria[];
 
   public constructor(options?: Partial<ComboFilterSettings>) {
     this.settings = Object.assign({}, defaultSettings, options);

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -1,12 +1,13 @@
 import { Character } from "../melee/characters";
 import { ComboType, GameStartType } from "slp-parser-js";
-import { MatchesPlayerName, ExcludesChainGrabs, ExcludesWobbles, SatisfiesMinComboPercent, ExcludesLargeSingleHit, ExcludesCPUs, IsOneVsOne, ComboDidKill, MatchesCharacter, MatchesPortNumber } from "./criteria";
+import { MatchesPlayerName, ExcludesChainGrabs, ExcludesWobbles, SatisfiesMinComboPercent, ExcludesLargeSingleHit, ExcludesCPUs, IsOneVsOne, ComboDidKill, MatchesCharacter, MatchesPortNumber, SatisfiesMinComboLength } from "./criteria";
 
 export interface ComboFilterSettings {
   chainGrabbers: Character[];
   characterFilter: Character[];
   portFilter: number[];
   nameTags: string[];
+  minComboLength: number;
   minComboPercent: number;
   comboMustKill: boolean;
   excludeCPUs: boolean;
@@ -27,6 +28,7 @@ const defaultSettings: ComboFilterSettings = {
   characterFilter: [],
   portFilter: [],
   nameTags: [],
+  minComboLength: 0,
   minComboPercent: 60,
   comboMustKill: true,
   excludeCPUs: true,
@@ -55,6 +57,7 @@ export class ComboFilter {
       new MatchesCharacter(),
       new ExcludesChainGrabs(),
       new ExcludesWobbles(),
+      new SatisfiesMinComboLength(),
       new SatisfiesMinComboPercent(),
       new ExcludesLargeSingleHit(),
       new ExcludesCPUs(),

--- a/src/combo/filter.ts
+++ b/src/combo/filter.ts
@@ -28,7 +28,7 @@ const defaultSettings: ComboFilterSettings = {
   characterFilter: [],
   portFilter: [0, 1, 2, 3], // Enable combos for all ports
   nameTags: [],
-  minComboLength: 0,
+  minComboLength: 3,
   minComboPercent: 60,
   comboMustKill: true,
   excludeCPUs: true,

--- a/src/realtime/realtime.ts
+++ b/src/realtime/realtime.ts
@@ -7,6 +7,9 @@ import { SlpParser, GameStartType, GameEndType, Command, PostFrameUpdateType, St
 import { StockComputer } from "../stats/stocks";
 import { ComboComputer } from "../stats/combos";
 
+// Export the parameter types for events
+export { GameStartType, GameEndType, ComboType, StockType } from "slp-parser-js";
+
 interface SlippiRealtimeEvents {
   gameStart: GameStartType;
   gameEnd: GameEndType;

--- a/src/utils/dolphin.ts
+++ b/src/utils/dolphin.ts
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { ComboType, Frames } from "slp-parser-js";
+import { shuffle } from "lodash";
 
 interface DolphinQueue {
   mode: string;
@@ -10,6 +11,7 @@ interface DolphinQueue {
 }
 
 const defaultSettings = {
+  shuffle: true,
   startBuffer: 240,
   endBuffer: 180,
 };
@@ -74,12 +76,13 @@ export class DolphinComboQueue {
   }
 
   private _dataToWrite(): string {
+    const combos = (this.options.shuffle) ? shuffle(this.combos) : this.combos;
     const queue: DolphinQueue = {
       mode: "queue",
       replay: "",
       isRealTimeMode: false,
       outputOverlayFiles: true,
-      queue: this.combos,
+      queue: combos,
     };
     return JSON.stringify(queue, null, 2);
   }

--- a/src/utils/dolphin.ts
+++ b/src/utils/dolphin.ts
@@ -49,6 +49,10 @@ export class DolphinComboQueue {
     });
   }
 
+  public length(): number {
+    return this.combos.length;
+  }
+
   public clear(): void {
     this.combos = [];
   }
@@ -57,19 +61,27 @@ export class DolphinComboQueue {
     this.options = Object.assign({}, this.options, settings);
   }
 
-  public writeFileSync(filePath: string): void {
+  public writeFileSync(filePath: string): number {
     const data = this._dataToWrite();
     fs.writeFileSync(filePath, data);
+    return this.length();
   }
 
-  public async writeFile(filePath: string): Promise<void> {
+  /**
+   * Asynchronously writes out the combos to a JSON file
+   *
+   * @param {string} filePath The name of the combos file
+   * @returns {Promise<number>} The number of combos written out to the file
+   * @memberof DolphinComboQueue
+   */
+  public async writeFile(filePath: string): Promise<number> {
     return new Promise((resolve, reject): void => {
       const data = this._dataToWrite();
       fs.writeFile(filePath, data, (err) => {
         if (err) {
           reject(err);
         } else {
-          resolve();
+          resolve(this.length());
         }
       });
     });

--- a/yarn.lock
+++ b/yarn.lock
@@ -938,10 +938,10 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@~2.20.0:
-  version "2.20.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
-  integrity sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ==
+commander@~2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -1664,9 +1664,9 @@ growly@^1.3.0:
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
 handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"
@@ -4222,11 +4222,11 @@ typescript@^3.6.2:
   integrity sha512-lmQ4L+J6mnu3xweP8+rOrUwzmN+MRAj7TgtJtDaXE5PMyX2kCrklhg3rvOsOIfNeAWMQWO2F1GPc1kMD2vLAfw==
 
 uglify-js@^3.1.4:
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.6.0.tgz#704681345c53a8b2079fb6cec294b05ead242ff5"
-  integrity sha512-W+jrUHJr3DXKhrsS7NUVxn3zqMOFn0hL/Ei6v0anCIMoKC93TjcflTagwIHLW7SfMFfiQuktQyFVCFHGUE0+yg==
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.7.3.tgz#f918fce9182f466d5140f24bb0ff35c2d32dcc6a"
+  integrity sha512-7tINm46/3puUA4hCkKYo4Xdts+JDaVC9ZPRcG8Xw9R4nhO/gZgUM3TENq8IF4Vatk8qCig4MzP/c8G4u2BkVQg==
   dependencies:
-    commander "~2.20.0"
+    commander "~2.20.3"
     source-map "~0.6.1"
 
 union-value@^1.0.0:


### PR DESCRIPTION
This PR makes the following changes:
* adds an option to shuffle combo order when writing Dolphin combos
* adds ability to filter by port number
* adds ability to filter by combo length
* fixes a security issue in a dependency