### PR TITLE
Only export the Dolphin payload generation function

### DIFF
--- a/src/utils/dolphin.ts
+++ b/src/utils/dolphin.ts
@@ -2,14 +2,14 @@ import fs from "fs-extra";
 import { ComboType, Frames } from "slp-parser-js";
 import { shuffle } from "lodash";
 
-interface DolphinPlaybackItem {
+export interface DolphinPlaybackItem {
   path: string;
   combo?: ComboType;
   gameStation?: string;
   gameStartAt?: string;
 }
 
-interface DolphinQueue {
+interface DolphinQueueFormat {
   mode: string;
   replay: string;
   isRealTimeMode: boolean;
@@ -36,13 +36,13 @@ interface DolphinEntry {
   gameStartAt?: string;
 }
 
-export type DolphinEntryQueueOptions = typeof defaultSettings;
+export type DolphinPlaybackQueueOptions = typeof defaultSettings;
 
-export class DolphinEntryQueue implements Iterable<DolphinPlaybackItem>{
+export class DolphinPlaybackQueue implements Iterable<DolphinPlaybackItem>{
   private items = new Array<DolphinPlaybackItem>();
 
-  public push(entry: DolphinPlaybackItem): void {
-    this.items.push(entry);
+  public push(item: DolphinPlaybackItem): void {
+    this.items.push(item);
   }
 
   public entries(): IterableIterator<[number, DolphinPlaybackItem]> {
@@ -57,7 +57,7 @@ export class DolphinEntryQueue implements Iterable<DolphinPlaybackItem>{
     this.items = [];
   }
 
-  public writeFileSync(filePath: string, options?: Partial<DolphinEntryQueueOptions>): number {
+  public writeFileSync(filePath: string, options?: Partial<DolphinPlaybackQueueOptions>): number {
     const data = this._dataToWrite(options);
     fs.writeFileSync(filePath, data);
     return this.length();
@@ -68,9 +68,9 @@ export class DolphinEntryQueue implements Iterable<DolphinPlaybackItem>{
    *
    * @param {string} filePath The name of the combos file
    * @returns {Promise<number>} The number of combos written out to the file
-   * @memberof DolphinEntryQueue
+   * @memberof DolphinPlaybackQueue
    */
-  public async writeFile(filePath: string, options?: Partial<DolphinEntryQueueOptions>): Promise<number> {
+  public async writeFile(filePath: string, options?: Partial<DolphinPlaybackQueueOptions>): Promise<number> {
     const data = this._dataToWrite(options);
     await fs.writeFile(filePath, data);
     return this.length();
@@ -97,11 +97,11 @@ export class DolphinEntryQueue implements Iterable<DolphinPlaybackItem>{
     }
   }
 
-  private _dataToWrite(options: Partial<DolphinEntryQueueOptions>): string {
-    const opts: DolphinEntryQueueOptions = Object.assign({}, defaultSettings, options);
-    const entries = (opts.shuffle) ? shuffle(this.items) : this.items;
+  private _dataToWrite(options: Partial<DolphinPlaybackQueueOptions>): string {
+    const opts: DolphinPlaybackQueueOptions = Object.assign({}, defaultSettings, options);
+    const entries = opts.shuffle ? shuffle(this.items) : this.items;
     const queue = entries.map(entry => mapDolphinEntry(entry, opts.startBuffer, opts.endBuffer));
-    const dolphinQueue: DolphinQueue = {
+    const dolphinQueue: DolphinQueueFormat = {
       mode: opts.mode,
       replay: opts.replay,
       isRealTimeMode: opts.isRealTimeMode,

--- a/src/utils/dolphin.ts
+++ b/src/utils/dolphin.ts
@@ -2,21 +2,33 @@ import fs from "fs-extra";
 import { ComboType, Frames } from "slp-parser-js";
 import { shuffle } from "lodash";
 
+interface DolphinPlaybackItem {
+  path: string;
+  combo?: ComboType;
+  gameStation?: string;
+  gameStartAt?: string;
+}
+
 interface DolphinQueue {
   mode: string;
   replay: string;
   isRealTimeMode: boolean;
   outputOverlayFiles: boolean;
-  queue: DolphinCombo[];
+  queue: DolphinEntry[];
 }
 
 const defaultSettings = {
   shuffle: true,
+  mode: "queue",
+  replay: "",
+  isRealTimeMode: false,
+  outputOverlayFiles: true,
   startBuffer: 240,
   endBuffer: 180,
+  prettify: true,
 };
 
-interface DolphinCombo {
+interface DolphinEntry {
   path: string;
   startFrame?: number;
   endFrame?: number;
@@ -24,44 +36,29 @@ interface DolphinCombo {
   gameStartAt?: string;
 }
 
-export type DolphinComboQueueOptions = typeof defaultSettings;
+export type DolphinEntryQueueOptions = typeof defaultSettings;
 
-export class DolphinComboQueue {
-  private options: DolphinComboQueueOptions;
-  private combos: DolphinCombo[];
+export class DolphinEntryQueue implements Iterable<DolphinPlaybackItem>{
+  private items = new Array<DolphinPlaybackItem>();
 
-  public constructor(options?: Partial<DolphinComboQueueOptions>) {
-    this.options = Object.assign({}, defaultSettings, options);
-    this.combos = new Array<DolphinCombo>();
+  public push(entry: DolphinPlaybackItem): void {
+    this.items.push(entry);
   }
 
-  public addCombo(path: string, combo: ComboType, gameStation?: string, gameStartAt?: string): void {
-    const startFrame = Math.max(Frames.FIRST, combo.startFrame - this.options.startBuffer);
-    // If endFrame is undefined it will just play to the end
-    const endFrame = combo.endFrame ? combo.endFrame + this.options.endBuffer : undefined;
-    this.combos.push({
-      path,
-      startFrame,
-      endFrame,
-      gameStation,
-      gameStartAt,
-    });
+  public entries(): IterableIterator<[number, DolphinPlaybackItem]> {
+    return this.items.entries();
   }
 
   public length(): number {
-    return this.combos.length;
+    return this.items.length;
   }
 
   public clear(): void {
-    this.combos = [];
+    this.items = [];
   }
 
-  public updateSettings(settings: Partial<DolphinComboQueueOptions>): void {
-    this.options = Object.assign({}, this.options, settings);
-  }
-
-  public writeFileSync(filePath: string): number {
-    const data = this._dataToWrite();
+  public writeFileSync(filePath: string, options?: Partial<DolphinEntryQueueOptions>): number {
+    const data = this._dataToWrite(options);
     fs.writeFileSync(filePath, data);
     return this.length();
   }
@@ -71,23 +68,65 @@ export class DolphinComboQueue {
    *
    * @param {string} filePath The name of the combos file
    * @returns {Promise<number>} The number of combos written out to the file
-   * @memberof DolphinComboQueue
+   * @memberof DolphinEntryQueue
    */
-  public async writeFile(filePath: string): Promise<number> {
-    const data = this._dataToWrite();
+  public async writeFile(filePath: string, options?: Partial<DolphinEntryQueueOptions>): Promise<number> {
+    const data = this._dataToWrite(options);
     await fs.writeFile(filePath, data);
     return this.length();
   }
 
-  private _dataToWrite(): string {
-    const combos = (this.options.shuffle) ? shuffle(this.combos) : this.combos;
-    const queue: DolphinQueue = {
-      mode: "queue",
-      replay: "",
-      isRealTimeMode: false,
-      outputOverlayFiles: true,
-      queue: combos,
-    };
-    return JSON.stringify(queue, null, 2);
+  // Define the iterator so we can iterate through the list of items
+  public [Symbol.iterator](): Iterator<DolphinPlaybackItem, any, undefined> {
+    let counter = 0;
+    const items = this.items;
+    return {
+      next(): IteratorResult<DolphinPlaybackItem, any> {
+        if (++counter < items.length) {
+          return {
+            done: false,
+            value: items[counter - 1],
+          }
+        } else {
+          return {
+            done: true,
+            value: undefined,
+          }
+        }
+      }
+    }
   }
+
+  private _dataToWrite(options: Partial<DolphinEntryQueueOptions>): string {
+    const opts: DolphinEntryQueueOptions = Object.assign({}, defaultSettings, options);
+    const entries = (opts.shuffle) ? shuffle(this.items) : this.items;
+    const queue = entries.map(entry => mapDolphinEntry(entry, opts.startBuffer, opts.endBuffer));
+    const dolphinQueue: DolphinQueue = {
+      mode: opts.mode,
+      replay: opts.replay,
+      isRealTimeMode: opts.isRealTimeMode,
+      outputOverlayFiles: opts.outputOverlayFiles,
+      queue,
+    };
+    const spaces = opts.prettify ? 2 : undefined;
+    return JSON.stringify(dolphinQueue, undefined, spaces);
+  }
+
 }
+
+const mapDolphinEntry = (entry: DolphinPlaybackItem, startBuffer: number, endBuffer: number): DolphinEntry => {
+  const { path, gameStation, gameStartAt, combo } = entry;
+  const dolphinEntry: DolphinEntry = {
+    path,
+    gameStation,
+    gameStartAt,
+  };
+  if (combo) {
+    dolphinEntry.startFrame = Math.max(Frames.FIRST, combo.startFrame - startBuffer);
+    // If endFrame is undefined it will just play to the end
+    if (combo.endFrame) {
+      dolphinEntry.endFrame = combo.endFrame + endBuffer;
+    }
+  }
+  return dolphinEntry;
+};

--- a/src/utils/dolphin.ts
+++ b/src/utils/dolphin.ts
@@ -1,4 +1,3 @@
-import fs from "fs-extra";
 import { ComboType, Frames } from "slp-parser-js";
 import { shuffle } from "lodash";
 
@@ -38,80 +37,19 @@ interface DolphinEntry {
 
 export type DolphinPlaybackQueueOptions = typeof defaultSettings;
 
-export class DolphinPlaybackQueue implements Iterable<DolphinPlaybackItem>{
-  private items = new Array<DolphinPlaybackItem>();
-
-  public push(item: DolphinPlaybackItem): void {
-    this.items.push(item);
-  }
-
-  public entries(): IterableIterator<[number, DolphinPlaybackItem]> {
-    return this.items.entries();
-  }
-
-  public length(): number {
-    return this.items.length;
-  }
-
-  public clear(): void {
-    this.items = [];
-  }
-
-  public writeFileSync(filePath: string, options?: Partial<DolphinPlaybackQueueOptions>): number {
-    const data = this._dataToWrite(options);
-    fs.writeFileSync(filePath, data);
-    return this.length();
-  }
-
-  /**
-   * Asynchronously writes out the combos to a JSON file
-   *
-   * @param {string} filePath The name of the combos file
-   * @returns {Promise<number>} The number of combos written out to the file
-   * @memberof DolphinPlaybackQueue
-   */
-  public async writeFile(filePath: string, options?: Partial<DolphinPlaybackQueueOptions>): Promise<number> {
-    const data = this._dataToWrite(options);
-    await fs.writeFile(filePath, data);
-    return this.length();
-  }
-
-  // Define the iterator so we can iterate through the list of items
-  public [Symbol.iterator](): Iterator<DolphinPlaybackItem, any, undefined> {
-    let counter = 0;
-    const items = this.items;
-    return {
-      next(): IteratorResult<DolphinPlaybackItem, any> {
-        if (++counter < items.length) {
-          return {
-            done: false,
-            value: items[counter - 1],
-          }
-        } else {
-          return {
-            done: true,
-            value: undefined,
-          }
-        }
-      }
-    }
-  }
-
-  private _dataToWrite(options: Partial<DolphinPlaybackQueueOptions>): string {
-    const opts: DolphinPlaybackQueueOptions = Object.assign({}, defaultSettings, options);
-    const entries = opts.shuffle ? shuffle(this.items) : this.items;
-    const queue = entries.map(entry => mapDolphinEntry(entry, opts.startBuffer, opts.endBuffer));
-    const dolphinQueue: DolphinQueueFormat = {
-      mode: opts.mode,
-      replay: opts.replay,
-      isRealTimeMode: opts.isRealTimeMode,
-      outputOverlayFiles: opts.outputOverlayFiles,
-      queue,
-    };
-    const spaces = opts.prettify ? 2 : undefined;
-    return JSON.stringify(dolphinQueue, undefined, spaces);
-  }
-
+export const generateDolphinQueuePayload = (items: DolphinPlaybackItem[], options?: Partial<DolphinPlaybackQueueOptions>): string => {
+  const opts: DolphinPlaybackQueueOptions = Object.assign({}, defaultSettings, options);
+  const entries = opts.shuffle ? shuffle(items) : items;
+  const queue = entries.map(entry => mapDolphinEntry(entry, opts.startBuffer, opts.endBuffer));
+  const dolphinQueue: DolphinQueueFormat = {
+    mode: opts.mode,
+    replay: opts.replay,
+    isRealTimeMode: opts.isRealTimeMode,
+    outputOverlayFiles: opts.outputOverlayFiles,
+    queue,
+  };
+  const spaces = opts.prettify ? 2 : undefined;
+  return JSON.stringify(dolphinQueue, undefined, spaces);
 }
 
 const mapDolphinEntry = (entry: DolphinPlaybackItem, startBuffer: number, endBuffer: number): DolphinEntry => {


### PR DESCRIPTION
The previous implementation tracked a list of combos and was also inflexible for filtering down combos.

This PR removes the queue class and instead exports the function that generates the payload to be written to JSON. This makes the filtering of combos before writing the payload more flexible, and it also tracks file paths instead of combos. This allows files to be queued.