### PR TITLE
Use built-in FILE_PATH dolphin cout message

### DIFF
--- a/src/utils/dolphin/launcher.ts
+++ b/src/utils/dolphin/launcher.ts
@@ -1,16 +1,8 @@
-import fs from "fs-extra";
-
 import { ChildProcess, execFile } from "child_process";
-import { Subject, Observable, zip, from, merge } from "rxjs";
-import { filter, mapTo, takeUntil } from "rxjs/operators";
+import { Subject, Observable, merge } from "rxjs";
+import { filter, mapTo } from "rxjs/operators";
 
-import { DolphinQueueFormat } from "./queue";
 import { DolphinOutput, DolphinPlaybackStatus } from "./output";
-
-
-// Node child processes crash if too much data has been sent to stdout.
-// We set the max buffer to a really large number to avoid crashing Dolphin.
-const MAX_BUFFER = 2 ** 20;
 
 // Configurable options
 interface DolphinLauncherOptions {
@@ -18,15 +10,16 @@ interface DolphinLauncherOptions {
   batch: boolean;
   startBuffer: number;
   endBuffer: number;
+  maxNodeBuffer: number;
 }
 
 const defaultDolphinLauncherOptions = {
   meleeIsoPath: "",
   batch: false,
-  startBuffer: 1,   // Sometimes Dolphin misses the start frame so start from the following frame
-  endBuffer: 1,     // Match the start frame because why not
+  startBuffer: 1,           // Sometimes Dolphin misses the start frame so start from the following frame
+  endBuffer: 1,             // Match the start frame because why not
+  maxNodeBuffer: Infinity,  // This is the max amount of data that can be processed through stdout
 }
-
 
 export class DolphinLauncher {
   public dolphin: ChildProcess | null = null;
@@ -81,7 +74,7 @@ export class DolphinLauncher {
     if (this.options.batch) {
       params.push("-b")
     }
-    return execFile(this.dolphinPath, params, { maxBuffer: MAX_BUFFER });
+    return execFile(this.dolphinPath, params, { maxBuffer: this.options.maxNodeBuffer });
   }
 
 }

--- a/src/utils/dolphin/output.spec.ts
+++ b/src/utils/dolphin/output.spec.ts
@@ -1,0 +1,57 @@
+import os from "os";
+import sinon from "sinon";
+
+import { Transform } from "stream";
+import { Subscription } from "rxjs";
+import { DolphinOutput } from "./output";
+
+describe("when reading dolphin playback stdout", () => {
+  const subscription = new Subscription();
+
+  afterAll(() => {
+    subscription.unsubscribe();
+  });
+
+  it("can parse command messages", async (finishJest) => {
+    const inoutStream = new Transform();
+    const filepath = "C:/abc/def";
+    const payloadToWrite = [
+      `[FILE_PATH] ${filepath}`,
+      "[PLAYBACK_START_FRAME] 0",
+      "[GAME_END_FRAME] 4",
+      "[PLAYBACK_END_FRAME] 3",
+      "[CURRENT_FRAME] 0",
+      "[CURRENT_FRAME] 1",
+      "[CURRENT_FRAME] 2",
+      "[CURRENT_FRAME] 3",
+      "[NO_GAME]",
+    ].join(os.EOL);
+
+    const statusSpy = sinon.spy();
+    const filenameSpy = sinon.spy();
+    const dolphinOutput = new DolphinOutput();
+    subscription.add(
+      dolphinOutput.playbackFilename$.subscribe(name => {
+        expect(name).toEqual(filepath);
+        filenameSpy();
+      }),
+    );
+    subscription.add(
+      dolphinOutput.playbackStatus$.subscribe(payload => {
+        statusSpy();
+      }),
+    );
+
+    inoutStream.once("finish", () => {
+        expect(filenameSpy.callCount).toEqual(1);
+        expect(statusSpy.callCount).toEqual(4);
+        finishJest();
+    });
+
+    inoutStream.push(payloadToWrite);
+    inoutStream.pipe(dolphinOutput);
+    inoutStream.end();
+
+  });
+
+});

--- a/src/utils/dolphin/output.spec.ts
+++ b/src/utils/dolphin/output.spec.ts
@@ -3,7 +3,8 @@ import sinon from "sinon";
 
 import { Transform } from "stream";
 import { Subscription } from "rxjs";
-import { DolphinOutput } from "./output";
+import { DolphinOutput, DolphinPlaybackStatus } from "./output";
+import { filter, map } from "rxjs/operators";
 
 describe("when reading dolphin playback stdout", () => {
   const subscription = new Subscription();
@@ -30,8 +31,13 @@ describe("when reading dolphin playback stdout", () => {
     const statusSpy = sinon.spy();
     const filenameSpy = sinon.spy();
     const dolphinOutput = new DolphinOutput();
+
+    const filenames$ = dolphinOutput.playbackStatus$.pipe(
+        filter(playback => playback.status === DolphinPlaybackStatus.FILE_LOADED),
+        map(playback => playback.data.path),
+    );
     subscription.add(
-      dolphinOutput.playbackFilename$.subscribe(name => {
+      filenames$.subscribe(name => {
         expect(name).toEqual(filepath);
         filenameSpy();
       }),

--- a/src/utils/dolphin/output.spec.ts
+++ b/src/utils/dolphin/output.spec.ts
@@ -48,7 +48,7 @@ describe("when reading dolphin playback stdout", () => {
       }),
     );
 
-    inoutStream.once("finish", () => {
+    dolphinOutput.once("finish", () => {
         expect(filenameSpy.callCount).toEqual(1);
         expect(statusSpy.callCount).toEqual(4);
         finishJest();


### PR DESCRIPTION
This PR updates the dolphin output to use the built in `[FILE_PATH]` dolphin command. See https://github.com/project-slippi/Ishiiruka/pull/27 for more details.