### PR TITLE
Track Dolphin playback state

### DIFF
--- a/src/utils/dolphin/launcher.ts
+++ b/src/utils/dolphin/launcher.ts
@@ -22,8 +22,8 @@ export class DolphinLauncher {
 
   public output: DolphinOutput;
 
-  private dolphinQuitSource = new Subject<void>();
-  public dolphinQuit$ = this.dolphinQuitSource.asObservable();
+  private dolphinExitSource = new Subject<number>();
+  public dolphinExit$ = this.dolphinExitSource.asObservable();
 
   public playbackEnd$: Observable<void>;
 
@@ -32,7 +32,7 @@ export class DolphinLauncher {
     this.output = new DolphinOutput(this.options);
     this.playbackEnd$ = merge(
       this.output.playbackStatus$.pipe(filter(payload => payload.status === DolphinPlaybackStatus.QUEUE_EMPTY)),
-      this.dolphinQuit$,
+      this.dolphinExit$,
     ).pipe(
       mapTo(undefined),
     );
@@ -51,7 +51,7 @@ export class DolphinLauncher {
     }
 
     this.dolphin = this._startDolphin(comboFilePath);
-    this.dolphin.on("exit", () => this.dolphinQuitSource.next());
+    this.dolphin.on("exit", (exitCode) => this.dolphinExitSource.next(exitCode));
     // Pipe to the dolphin output but don't end
     this.dolphin.stdout.pipe(this.output, { end: false });
   }

--- a/src/utils/dolphin/launcher.ts
+++ b/src/utils/dolphin/launcher.ts
@@ -51,7 +51,7 @@ export class DolphinLauncher {
     }
 
     this.dolphin = this._executeFile(comboFilePath);
-    this.dolphin.on("close", () => this.dolphinQuitSource.next());
+    this.dolphin.on("exit", () => this.dolphinQuitSource.next());
     // Pipe to the dolphin output but don't end
     this.dolphin.stdout.pipe(this.output, { end: false });
   }

--- a/src/utils/dolphin/launcher.ts
+++ b/src/utils/dolphin/launcher.ts
@@ -50,13 +50,13 @@ export class DolphinLauncher {
       this.dolphin = null;
     }
 
-    this.dolphin = this._executeFile(comboFilePath);
+    this.dolphin = this._startDolphin(comboFilePath);
     this.dolphin.on("exit", () => this.dolphinQuitSource.next());
     // Pipe to the dolphin output but don't end
     this.dolphin.stdout.pipe(this.output, { end: false });
   }
 
-  private _executeFile(comboFilePath: string): ChildProcessWithoutNullStreams {
+  private _startDolphin(comboFilePath: string): ChildProcessWithoutNullStreams {
     if (!this.options.dolphinPath) {
       throw new Error("Dolphin path is not set!");
     }

--- a/src/utils/dolphin/launcher.ts
+++ b/src/utils/dolphin/launcher.ts
@@ -1,8 +1,7 @@
 import { spawn, ChildProcessWithoutNullStreams } from "child_process";
-import { Subject, Observable, merge } from "rxjs";
-import { filter, mapTo } from "rxjs/operators";
+import { Subject } from "rxjs";
 
-import { DolphinOutput, DolphinPlaybackStatus } from "./output";
+import { DolphinOutput } from "./output";
 
 // Configurable options
 const defaultDolphinLauncherOptions = {
@@ -17,25 +16,16 @@ const defaultDolphinLauncherOptions = {
 type DolphinLauncherOptions = typeof defaultDolphinLauncherOptions;
 
 export class DolphinLauncher {
+  public output: DolphinOutput;
   public dolphin: ChildProcessWithoutNullStreams | null = null;
   protected options: DolphinLauncherOptions;
-
-  public output: DolphinOutput;
 
   private dolphinExitSource = new Subject<number>();
   public dolphinExit$ = this.dolphinExitSource.asObservable();
 
-  public playbackEnd$: Observable<void>;
-
   public constructor(options?: Partial<DolphinLauncherOptions>) {
     this.options = Object.assign({}, defaultDolphinLauncherOptions, options);
     this.output = new DolphinOutput(this.options);
-    this.playbackEnd$ = merge(
-      this.output.playbackStatus$.pipe(filter(payload => payload.status === DolphinPlaybackStatus.QUEUE_EMPTY)),
-      this.dolphinExit$,
-    ).pipe(
-      mapTo(undefined),
-    );
   }
 
   public updateSettings(options: Partial<DolphinLauncherOptions>): void {


### PR DESCRIPTION
This PR changes the Dolphin playback to use `spawn` instead of `exec`. This lets us utilise Node streams for Dolphin `stdout` instead of using a fixed-size buffer. It also replaces the `dolphinQuit` observable to be `dolphinRunning` to track running status.