### PR TITLE
Feat/debounce frame

### DIFF
--- a/src/operators/frames.spec.ts
+++ b/src/operators/frames.spec.ts
@@ -1,0 +1,53 @@
+import { TestScheduler } from "rxjs/testing";
+import { from } from "rxjs";
+import { debounceFrame } from "./frames";
+import { tap } from "rxjs/operators";
+
+interface TestFrame {
+  frame: number;
+  data: string;
+}
+
+describe("frame operators", () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler((actual: TestFrame, expected: TestFrame) => {
+      expect(actual).toEqual(expected);
+    });
+  });
+
+  it("can debounce multiple frames", () => {
+    const a: TestFrame = {
+      frame: 1,
+      data: "a",
+    };
+    const a2: TestFrame = {
+      frame: 1,
+      data: "b",
+    };
+    const b: TestFrame = {
+      frame: 2,
+      data: "a",
+    };
+    const b2: TestFrame = {
+      frame: 2,
+      data: "b",
+    };
+    const c: TestFrame = {
+      frame: 3,
+      data: "a",
+    };
+
+    testScheduler.run(({ expectObservable }) => {
+      // We expect 3 values
+      const expectedMarble = "(abc|)";
+      const expectedValues = { a: a2, b: b2, c };
+      const source$ = from([a, a2, b, b2, c]).pipe(
+        debounceFrame(250), // Debounce if we get multiple of the same frame
+        tap((x) => console.log(JSON.stringify(x))),
+      );
+      expectObservable(source$).toBe(expectedMarble, expectedValues);
+    });
+  });
+});

--- a/src/operators/throttleInputButtons.spec.ts
+++ b/src/operators/throttleInputButtons.spec.ts
@@ -1,4 +1,4 @@
-import {TestScheduler} from "rxjs/testing";
+import { TestScheduler } from "rxjs/testing";
 import { from } from "rxjs";
 import { InputButtonCombo } from "..";
 import { throttleInputButtons } from "./throttleInputButtons";
@@ -8,8 +8,7 @@ describe("throttleInputButtons operator", () => {
 
   beforeEach(() => {
     testScheduler = new TestScheduler((actual: InputButtonCombo, expected: InputButtonCombo) => {
-      // We just want to compare the frame
-      expect(actual.frame).toEqual(expected.frame);
+      expect(actual).toEqual(expected);
     });
   });
 
@@ -17,7 +16,7 @@ describe("throttleInputButtons operator", () => {
     const a: InputButtonCombo = {
       frame: 30,
       playerIndex: 0,
-      combo:  ["X"],
+      combo: ["X"],
       duration: 1,
     };
     const a2: InputButtonCombo = {
@@ -27,24 +26,24 @@ describe("throttleInputButtons operator", () => {
     const b: InputButtonCombo = {
       ...a,
       frame: 78,
-    }
+    };
     const b2: InputButtonCombo = {
       ...a,
       frame: 112,
-    }
+    };
     const c: InputButtonCombo = {
       ...a,
       frame: 113,
-    }
+    };
 
-    testScheduler.run(({expectObservable}) => {
+    testScheduler.run(({ expectObservable }) => {
       // We expect 3 values
-      const expectedMarble = "a  b  (c|)";
+      const expectedMarble = "(abc|)";
       const expectedValues = { a, b, c };
       const source$ = from([a, a2, b, b2, c]).pipe(
-        throttleInputButtons(35),  // Throttle for 35 frames
-      )
+        throttleInputButtons(35), // Throttle for 35 frames
+      );
       expectObservable(source$).toBe(expectedMarble, expectedValues);
     });
   });
-})
+});


### PR DESCRIPTION
This was an attempt at frame finalization using the `debounce` operator. The performance was terrible since it had to do a debounce for each and every frame. Frame finalization has been solved since the `latestFinalizedFrame` field was added to the `@slippi/slippi-js` SDK in the `FrameBookendType`.

Preserving the changes for historical purposes in this PR.