### PR TITLE
Added toString to stocksRemaining

### DIFF
--- a/examples/custom-hud/index.js
+++ b/examples/custom-hud/index.js
@@ -46,7 +46,7 @@ realtime.stock.percentChange$.subscribe((payload) => {
 realtime.stock.countChange$.subscribe((payload) => {
   const player = payload.playerIndex + 1;
   console.log(`player ${player} stocks: ${payload.stocksRemaining}`);
-  setPlayerStock(player, payload.stocksRemaining);
+  setPlayerStock(player, payload.stocksRemaining.toString());
 });
 
 // Reset the text files on game end


### PR DESCRIPTION
I was getting an error when trying to run the `examples/custom-hud/index.js` 

![image](https://user-images.githubusercontent.com/10161188/99208373-37352080-278e-11eb-99df-8df09be696d1.png)

Adding `toString` to `stocksRemaining` fixed this.