### PR TITLE
Pass constructor options from SlpLiveStream via super

### DIFF
--- a/src/stream/slpLiveStream.ts
+++ b/src/stream/slpLiveStream.ts
@@ -1,4 +1,5 @@
-import type { Connection } from "@slippi/slippi-js";
+import type { Connection, SlpFileWriterOptions } from "@slippi/slippi-js";
+import type { WritableOptions } from "stream";
 import { ConnectionEvent, ConnectionStatus, ConsoleConnection, DolphinConnection } from "@slippi/slippi-js";
 
 import { RxSlpStream } from "./rxSlpStream";
@@ -24,8 +25,12 @@ export class SlpLiveStream extends RxSlpStream {
    */
   public connection: Connection;
 
-  public constructor(connectionType?: "dolphin" | "console") {
-    super();
+  public constructor(
+    connectionType?: "dolphin" | "console",
+    options?: Partial<SlpFileWriterOptions>,
+    opts?: WritableOptions,
+  ) {
+    super(options, opts);
     if (connectionType === "dolphin") {
       this.connection = new DolphinConnection();
     } else {


### PR DESCRIPTION
Enable use of constructor options in `SlpLiveStream` by passing them to the parent constructor (`RxSlpStream`) via `super`.

It's probably cleaner for `connectionType` to be an additional option rather than being its own argument to the constructor, but no need to break everyone's compatibility for that.