### PR TITLE
Fix address in dolphin/relay connection example

### DIFF
--- a/examples/dolphin-or-relay-connection/README.md
+++ b/examples/dolphin-or-relay-connection/README.md
@@ -20,7 +20,7 @@ yarn run build
 2. Prepare the example by changing directory into the example folder and installing the dependencies. 
 
 ```bash
-cd examples/relay-connection-or-dolphin
+cd examples/dolphin-or-relay-connection
 yarn install
 ```
 

--- a/examples/dolphin-or-relay-connection/index.js
+++ b/examples/dolphin-or-relay-connection/index.js
@@ -12,7 +12,7 @@ const { Ports } = require('@slippi/slippi-js')
 const { ConnectionStatus, SlpLiveStream, SlpRealTime, ComboFilter, generateDolphinQueuePayload } = require("@vinceau/slp-realtime");
 
 // TODO: Make sure you set these values!
-const ADDRESS = "localhost";  // leave as is for Dolphin or a relay on the same computer
+const ADDRESS = "127.0.0.1";  // leave as is for Dolphin or change to "localhost" for a relay on the same computer
 const PORT = Ports.DEFAULT;   // options are DEFAULT, RELAY_START, and LEGACY
 
 const outputCombosFile = "combos.json";   // The json file to write combos to


### PR DESCRIPTION
Fixing an issue with the Dolphin and relay connection example script

For dolphin, it seems like `127.0.0.1` works as the address while `localhost` does not. This seems to be consistent with [how `project-clippi` handles the address](https://github.com/vinceau/project-clippi/blob/master/src/renderer/store/models/slippi.ts#L124) for dolphin as well. Tested connecting to Dolphin on Windows and Mac